### PR TITLE
feat: add copy color button

### DIFF
--- a/src/Swatch.svelte
+++ b/src/Swatch.svelte
@@ -24,7 +24,6 @@
     @apply flex-1;
   }
 
-  .hex-code,
   .w-contrast,
   .b-contrast,
   .refColor {
@@ -46,7 +45,7 @@
   }
 
   .hex-code {
-    @apply mr-auto;
+    @apply font-mono;
   }
 </style>
 
@@ -69,6 +68,17 @@
   $: blackContrast =
     $settings.overlayContrast && chroma.contrast("#000", hexCode);
   $: refColor = $nearestRefColors[hexCode];
+
+  function copyToClipboard(text) {
+    navigator.clipboard.writeText(text).then(
+      () => {
+        // success
+      },
+      (err) => {
+        console.error(err);
+      }
+    );
+  }
 </script>
 
 <div
@@ -80,7 +90,29 @@
   <a class="click-area" href="#{hexCode}" on:click>
     <span class="sr-only">Select</span>
   </a>
-  {#if $settings.overlayHex}<span class="hex-code">{hexCode}</span>{/if}
+  {#if $settings.overlayHex}
+    <div class="flex justify-between content-around w-full px-4 z-10">
+      <div class="hex-code">{hexCode}</div>
+      <div>
+        <button on:click="{() => copyToClipboard(hexCode)}"
+          ><svg
+            xmlns="http://www.w3.org/2000/svg"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke-width="1.5"
+            stroke="currentColor"
+            class="w-4 h-4"
+          >
+            <path
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              d="M15.75 17.25v3.375c0 .621-.504 1.125-1.125 1.125h-9.75a1.125 1.125 0 0 1-1.125-1.125V7.875c0-.621.504-1.125 1.125-1.125H6.75a9.06 9.06 0 0 1 1.5.124m7.5 10.376h3.375c.621 0 1.125-.504 1.125-1.125V11.25c0-4.46-3.243-8.161-7.5-8.876a9.06 9.06 0 0 0-1.5-.124H9.375c-.621 0-1.125.504-1.125 1.125v3.5m7.5 10.375H9.375a1.125 1.125 0 0 1-1.125-1.125v-9.25m12 6.625v-1.875a3.375 3.375 0 0 0-3.375-3.375h-1.5a1.125 1.125 0 0 1-1.125-1.125v-1.5a3.375 3.375 0 0 0-3.375-3.375H9.75"
+            ></path>
+          </svg>
+        </button>
+      </div>
+    </div>
+  {/if}
   {#if refColor}
     <div class="refColor">
       <TinySwatch color="{refColor}" />


### PR DESCRIPTION
Closes #26

![image](https://github.com/saneef/color-color/assets/101593/6c27c369-0da5-4b47-9cfb-aeef48705a7b)

When toggling the hex overlay, the button also toggles.