### PR TITLE
Add RGB codes as an option

### DIFF
--- a/src/OverlayKnobs.svelte
+++ b/src/OverlayKnobs.svelte
@@ -6,5 +6,6 @@
 
 <ControlGroup title="Overlay">
   <Checkbox label="HEX code" bind:checked="{$settings.overlayHex}" />
+  <Checkbox label="RGB code" bind:checked="{$settings.overlayRgb}" />
   <Checkbox label="WCAG Contrast" bind:checked="{$settings.overlayContrast}" />
 </ControlGroup>

--- a/src/Palettes.svelte
+++ b/src/Palettes.svelte
@@ -100,6 +100,7 @@
           fillHeight
           isLight="{isLightColor(color.luminance)}"
           hexCode="{color.hex}"
+          rgbCode="{color.rgb}"
           whiteContrast="{color.whiteContrast}"
           blackContrast="{color.blackContrast}"
           refColor="{$nearestRefColors[color.hex]}"

--- a/src/Swatch.svelte
+++ b/src/Swatch.svelte
@@ -25,13 +25,21 @@
   }
 
   .hex-code,
-  .w-contrast,
-  .b-contrast,
+  .rgb-code,
   .refColor {
-    @apply px-4 font-mono;
+    @apply pl-4 font-mono;
   }
 
-  .hex-code,
+  .refColor {
+    @apply absolute bottom-0 right-0;
+  }
+
+  .w-contrast,
+  .b-contrast {
+    @apply pr-4;
+  }
+
+  .codes,
   .w-contrast,
   .b-contrast {
     @apply relative;
@@ -45,7 +53,7 @@
     @apply text-black;
   }
 
-  .hex-code {
+  .codes {
     @apply mr-auto;
   }
 </style>
@@ -56,6 +64,7 @@
   import CopyOnClick from "./CopyOnClick.svelte";
 
   export let hexCode = "#000";
+  export let rgbCode = "0, 0, 0";
   export let fillHeight = false;
   export let isLight = false;
   export let whiteContrast = 0;
@@ -72,18 +81,27 @@
   <a class="click-area" href="#{hexCode}" on:click>
     <span class="sr-only">Select</span>
   </a>
-  {#if $settings.overlayHex}
-    <span class="hex-code">
-      <CopyOnClick text="{hexCode}">{hexCode}</CopyOnClick>
-    </span>
-  {/if}
+  <div class="codes">
+    {#if $settings.overlayHex}
+      <div class="hex-code">
+        <CopyOnClick text="{hexCode}">{hexCode}</CopyOnClick>
+      </div>
+    {/if}
+    {#if $settings.overlayRgb}
+      <div class="rgb-code">
+        <CopyOnClick text="{rgbCode}">{rgbCode}</CopyOnClick>
+      </div>
+    {/if}
+  </div>
   {#if refColor}
     <div class="refColor">
       <TinySwatch color="{refColor}" />
     </div>
   {/if}
-  {#if $settings.overlayContrast}
-    <span class="b-contrast">{blackContrast.toFixed(2)}b</span>
-    <span class="w-contrast">{whiteContrast.toFixed(2)}w</span>
-  {/if}
+  <div>
+    {#if $settings.overlayContrast}
+      <div class="b-contrast">{blackContrast.toFixed(2)}b</div>
+      <div class="w-contrast">{whiteContrast.toFixed(2)}w</div>
+    {/if}
+  </div>
 </div>

--- a/src/TinySwatch.svelte
+++ b/src/TinySwatch.svelte
@@ -1,6 +1,6 @@
 <style lang="postcss">
   .tiny-swatch {
-    @apply block w-6 h-6 rounded;
+    @apply block w-6 h-6 m-1 rounded;
     box-shadow: inset 0px -1px 0 rgba(0, 0, 0, 0.35),
       inset 0px 1px 0 0 rgba(255, 255, 255, 0.55);
   }

--- a/src/store.js
+++ b/src/store.js
@@ -18,6 +18,7 @@ import {
 import { randomInt } from "./lib/math";
 import { jsonToSvg } from "./lib/svg";
 import { getStateFromUrl, getStatefulUrl } from "./lib/url";
+import { to as convert } from "colorjs.io/fn";
 
 const defaults = {
   steps: 9,
@@ -66,6 +67,7 @@ export const settings = writable(
     {
       overlayContrast: false,
       overlayHex: true,
+      overlayRgb: false,
       refColorsRaw: "",
       colorSpace: "okhsl",
     },
@@ -255,6 +257,9 @@ export const palettes = derived(
         const id = (i + 1) * (steps > 9 ? 10 : 100);
         const _color = createColorByHSL(h, s, l, $settings.colorSpace);
         const hex = colorToString(_color, "hex", "srgb");
+        const rgb = convert(_color, "srgb", { inGamut: true }).coords
+          .map(c => Math.floor(c * 255))
+          .join(", ");
         const chroma = getChroma(_color);
         const luminance = getLuminance(_color);
         const whiteContrast = contrast(_color, staticColors.white);
@@ -268,6 +273,7 @@ export const palettes = derived(
           s,
           l,
           hex,
+          rgb,
           chroma,
           luminance,
           whiteContrast,


### PR DESCRIPTION
An option to show 0-255 RGB codes alongside the hex codes has been added and implemented. This is useful for picking colors for programs that do not accept hex code, in my case Raylib, reducing a conversion step and making color-color easier to use for in these cases.
![Screenshot showing "RGB Code" checkbox alongside "Hex Code"](https://github.com/user-attachments/assets/caf8f179-9cc8-4673-87bd-d0d4d83fd84f)

Because the RGB codes tend to be longer, it was running into the reference color dialogue at smaller resolutions, so I moved it to the bottom-right corner. I also gave the black and white contrast ratios their own lines.
![Screenshot showing a swatch with the RGB code and the relocated reference color](https://github.com/user-attachments/assets/d4921f29-3d1a-4e3d-a70c-edf85b10ac92)
![Screenshot showing how the previous image looks at a smaller width](https://github.com/user-attachments/assets/0dbd4cb5-389b-40d4-a40f-e89d123ec426)

The interface can currently scale to a width of ~1220 pixels before lines start wrapping. A potential solution would be to increase the minimum width of the color palette areas when the RGB codes are shown, though I have not yet found where this is located.
